### PR TITLE
ci: add sonarcloud

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
     branches:
     - main
     - develop
+    - feature/sonarcloud
   pull_request:
     branches: 
     - main
@@ -40,9 +41,25 @@ jobs:
             go vet
             golint -set_exit_status
 
+  sonarcloud:
+    name: sonarcloud
+    needs: lint
+
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        # Disabling shallow clone is recommended for improving relevancy of reporting
+        fetch-depth: 0
+    - name: SonarCloud Scan
+      uses: sonarsource/sonarcloud-github-action@master
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
   test:
     name: test
-    needs: lint
+    needs: sonarcloud
 
     runs-on: ubuntu-latest
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,6 @@
+sonar.organization=nayrsirhc
+sonar.projectKey=nayrsirhc_doh
+
+# relative paths to source directories. More details and properties are described
+# in https://sonarcloud.io/documentation/project-administration/narrowing-the-focus/
+sonar.sources=.


### PR DESCRIPTION
# Sonarcloud

Adding sonarcloud functionality
```yaml
  sonarcloud:
    name: sonarcloud
    needs: lint

    runs-on: ubuntu-latest
    steps:
    - uses: actions/checkout@v2
      with:
        # Disabling shallow clone is recommended for improving relevancy of reporting
        fetch-depth: 0
    - name: SonarCloud Scan
      uses: sonarsource/sonarcloud-github-action@master
      env:
        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
```